### PR TITLE
Fixes #5: oo alias was incorrect

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -38,6 +38,6 @@ alias ohmyzsh="code ~/.oh-my-zsh"
 alias dl="cd ~/Downloads"
 alias dt="cd ~/Desktop"
 alias o="open"
-alias oo="tab"
+alias oo="open ."
 
 export EDITOR="code"


### PR DESCRIPTION
This alias is meant to open the pwd but was mistakenly set as 'tab'